### PR TITLE
added html, text, json, redirect response

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,26 @@
 [![Build Status](https://travis-ci.org/ytake/hungrr.svg?branch=master)](https://travis-ci.org/ytake/hungrr)
 
 `ytake/hungrr` is a Hack package containing implementations of the
-[PSR-7 HTTP message interfaces](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md)
+[Hack HTTP Request and Response Interfaces](https://github.com/hhvm/hack-http-request-response-interfaces)
 
-and [PSR-17 HTTP message factory interfaces](https://www.php-fig.org/psr/psr-17).
+PSR-7 was designed for PHP, not Hack, and some descisions do not fit smoothly with Hack's type system.
 
 Not Supported PHP
 
+## Requirements
+HHVM 3.29 and above.
+
+## Install
+
+via Composer
+
+```bash
+$ hhvm $(which composer) ytake/hungrr
+```
+
 ## Usage
 
-### Marshaling an incoming request
+## Marshaling an incoming request
 
 ```hack
 <?hh // strict
@@ -19,4 +30,65 @@ Not Supported PHP
 use type Ytake\Hungrr\ServerRequestFactory;
 
 $request = ServerRequestFactory::fromGlobals();
+```
+
+## Response
+
+### Json Response
+
+Constructor Detail
+
+```text
+public function __construct(
+  ImmMap<mixed, mixed> $payload,
+  Ytake\Hungrr\StatusCode $status,
+  dict<string, vec<string>> $headers,
+  int $encodingOptions
+)
+```
+
+Example
+
+```hack
+<?hh // strict
+
+use type Ytake\Hungrr\Uri;
+use type Ytake\Hungrr\StatusCode;
+use type Ytake\Hungrr\Response\RedirectResponse;
+
+$r = new JsonResponse(new ImmMap([
+  'json_encode' => ImmMap{
+    'HHVM' => 'Hack'
+  }
+]));
+```
+
+### Redirect Response
+
+Constructor Detail
+
+```text
+public function __construct(
+  mixed $uri,
+  Ytake\Hungrr\StatusCode $status,
+  dict<string, vec<string>> $headers
+)
+```
+
+$uri, MUST be a string or Facebook\Experimental\Http\Message\UriInterface instance.
+
+Example
+
+```hack
+<?hh // strict
+
+use type Ytake\Hungrr\Uri;
+use type Ytake\Hungrr\StatusCode;
+use type Ytake\Hungrr\Response\RedirectResponse;
+
+// use uri string
+$r = new RedirectResponse('/foo/bar');
+
+// use uri instance
+$r = new RedirectResponse(new Uri('https://example.com:10082/foo/bar'));
 ```

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
   },
   "autoload-dev": {
     "classmap": [
-      "tests/"
+      "tests/",
+      "tests/Response/"
     ]
   }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -91,9 +91,9 @@ class Response implements ResponseInterface {
   };
 
   public function __construct(
+    string $body = '',
     private StatusCode $status = StatusCode::OK,
     dict<string, vec<string>> $headers = dict[],
-    string $body = '',
     private string $protocol = '1.1',
     protected string $reason = ''
   ) {

--- a/src/Response/HtmlResponse.php
+++ b/src/Response/HtmlResponse.php
@@ -1,0 +1,39 @@
+<?hh // strict
+
+/**
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ *
+ * Copyright (c) 2018 Yuuki Takezawa
+ *
+ */
+
+namespace Ytake\Hungrr\Response;
+
+use type Ytake\Hungrr\Response;
+use type Ytake\Hungrr\StatusCode;
+
+class HtmlResponse extends Response {
+  use InjectContentTypeTrait;
+
+  public function __construct(
+    string $html,
+    StatusCode $status = StatusCode::OK,
+    dict<string, vec<string>> $headers = dict[]
+  ) {
+    parent::__construct(
+      $html,
+      $status,
+      /* HH_FIXME[3004] */
+      $this->injectContentType('text/html; charset=utf-8', $headers),
+    );
+  }
+}

--- a/src/Response/InjectContentTypeTrait.php
+++ b/src/Response/InjectContentTypeTrait.php
@@ -1,0 +1,41 @@
+<?hh // strict
+
+/**
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ *
+ * Copyright (c) 2018 Yuuki Takezawa
+ *
+ */
+
+namespace Ytake\Hungrr\Response;
+
+use type Ytake\Hungrr\Response;
+use namespace HH\Lib\{Vec, Str, C};
+
+trait InjectContentTypeTrait {
+  require extends Response;
+
+  private function injectContentType(
+    string $contentType,
+    dict<string, vec<string>> $headers
+  ): dict<string, vec<string>> {
+    $hasContentType = C\reduce(
+      Vec\keys($headers),
+      ($carry, $item) ==> $carry ?: (Str\lowercase($item) === 'content-type'),
+      false
+    );
+    if (!$hasContentType) {
+      $headers['content-type'] = vec[$contentType];
+    }
+    return $headers;
+  }
+}

--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -1,0 +1,93 @@
+<?hh // strict
+
+/**
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ *
+ * Copyright (c) 2018 Yuuki Takezawa
+ *
+ */
+
+namespace Ytake\Hungrr\Response;
+
+use type Ytake\Hungrr\Response;
+use type Ytake\Hungrr\StatusCode;
+
+use namespace Ytake\Hungrr\Exception;
+use namespace HH\Lib\Str;
+use const JSON_ERROR_NONE;
+
+use function json_encode;
+use function json_last_error;
+use function json_last_error_msg;
+
+class JsonResponse extends Response {
+  use InjectContentTypeTrait;
+
+  // JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES
+  const int DEFAULT_JSON_FLAGS = 79;
+
+  public function __construct(
+    protected ImmMap<mixed, mixed> $payload,
+    StatusCode $status = StatusCode::OK,
+    dict<string, vec<string>> $headers = dict[],
+    protected int $encodingOptions = self::DEFAULT_JSON_FLAGS
+  ) {
+    parent::__construct(
+      $this->jsonEncode($payload, $this->encodingOptions),
+      $status,
+      /* HH_FIXME[3004] */
+      $this->injectContentType('application/json', $headers),
+    );
+  }
+
+  public function withEncodingOptions(int $encodingOptions): this {
+    $new = clone $this;
+    $new->encodingOptions = $encodingOptions;
+    return $this->updateBodyFor($new);
+  }
+
+  private function jsonEncode(
+    ImmMap<mixed, mixed> $payload,
+    int $encodingOptions
+  ): string {
+    json_encode(null);
+    $json = json_encode($payload, $encodingOptions);
+    if (JSON_ERROR_NONE !== json_last_error()) {
+      throw new Exception\InvalidArgumentException(Str\format(
+        'Unable to encode data to JSON in %s: %s',
+        __CLASS__,
+        json_last_error_msg()
+      ));
+    }
+    return $json;
+  }
+
+  public function getPayload(): ImmMap<mixed, mixed> {
+    return $this->payload;
+  }
+
+  public function withPayload(ImmMap<mixed, mixed> $payload): this {
+    $new = clone $this;
+    $new->payload = $payload;
+    return $this->updateBodyFor($new);
+  }
+
+  public function getEncodingOptions(): int {
+    return $this->encodingOptions;
+  }
+
+  private function updateBodyFor(this $toUpdate): this {
+    $body = $this->jsonEncode($toUpdate->payload, $toUpdate->encodingOptions);
+    $toUpdate->getBody()->rawWriteBlocking($body);
+    return $toUpdate;
+  }
+}

--- a/src/Response/RedirectResponse.php
+++ b/src/Response/RedirectResponse.php
@@ -1,0 +1,53 @@
+<?hh // strict
+
+/**
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ *
+ * Copyright (c) 2018 Yuuki Takezawa
+ *
+ */
+
+namespace Ytake\Hungrr\Response;
+
+use type Ytake\Hungrr\Response;
+use type Ytake\Hungrr\StatusCode;
+use type Facebook\Experimental\Http\Message\UriInterface;
+
+use namespace Ytake\Hungrr\Exception;
+use namespace HH\Lib\Str;
+
+use function is_object;
+use function get_class;
+use function gettype;
+
+class RedirectResponse extends Response {
+
+  public function __construct(
+    mixed $uri,
+    StatusCode $status = StatusCode::FOUND,
+    dict<string, vec<string>> $headers = dict[]
+  ) {
+    if(!$uri is string && !$uri is UriInterface) {
+      throw new Exception\InvalidArgumentException(Str\format(
+        'Uri provided to %s MUST be a string or Facebook\Experimental\Http\Message\UriInterface instance; received "%s"',
+        __CLASS__,
+        (is_object($uri) ? get_class($uri) : gettype($uri))
+      ));
+    }
+    $headers['location'] = vec[(string) $uri];
+    parent::__construct(
+      '',
+      $status,
+      $headers,
+    );
+  }
+}

--- a/src/Response/TextResponse.php
+++ b/src/Response/TextResponse.php
@@ -1,0 +1,39 @@
+<?hh // strict
+
+/**
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ *
+ * Copyright (c) 2018 Yuuki Takezawa
+ *
+ */
+
+namespace Ytake\Hungrr\Response;
+
+use type Ytake\Hungrr\Response;
+use type Ytake\Hungrr\StatusCode;
+
+class TextResponse extends Response {
+  use InjectContentTypeTrait;
+
+  public function __construct(
+    string $text,
+    StatusCode $status = StatusCode::OK,
+    dict<string, vec<string>> $headers = dict[]
+  ) {
+    parent::__construct(
+      $text,
+      $status,
+      /* HH_FIXME[3004] */
+      $this->injectContentType('text/plain; charset=utf-8', $headers),
+    );
+  }
+}

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -18,7 +18,8 @@
 
 namespace Ytake\Hungrr;
 
-use type Facebook\Experimental\Http\Message\{ServerRequestInterface, UploadedFileInterface};
+use type Facebook\Experimental\Http\Message\ServerRequestInterface;
+use type Facebook\Experimental\Http\Message\UploadedFileInterface;
 
 use namespace Facebook\Experimental\Http\Message;
 

--- a/tests/Response/JsonResponseTest.php
+++ b/tests/Response/JsonResponseTest.php
@@ -1,0 +1,52 @@
+<?hh // strict
+
+use type Ytake\Hungrr\Response\JsonResponse;
+use type Ytake\Hungrr\StatusCode;
+use type Facebook\HackTest\HackTest;
+use function Facebook\FBExpect\expect;
+
+final class JsonResponseTest extends HackTest {
+
+  public function testShouldReturnEmptyJsonBody(): void {
+    $r = new JsonResponse(new ImmMap([]));
+    expect($r->getStatusCode())->toBeSame(200);
+    expect($r->getProtocolVersion())->toBeSame('1.1');
+    expect($r->getReasonPhrase())->toBeSame('OK');
+    expect($r->getHeaders())->toBeSame(dict[
+      'content-type' => vec['application/json'],
+    ]);
+    expect($r->readBody()->rawReadBlocking())->toBeSame('{}');
+  }
+
+  public function testShouldReturnJsonBody(): void {
+    $r = new JsonResponse(new ImmMap([
+      'testing' => ImmMap{
+        'HHVM' => 'Hack'
+      }
+    ]));
+    expect($r->getStatusCode())->toBeSame(200);
+    expect($r->getProtocolVersion())->toBeSame('1.1');
+    expect($r->getReasonPhrase())->toBeSame('OK');
+    expect($r->getHeaders())->toBeSame(dict[
+      'content-type' => vec['application/json'],
+    ]);
+    expect($r->readBody()->rawReadBlocking())->toBeSame('{"testing":{"HHVM":"Hack"}}');
+  }
+
+  public function testShouldReturnAppendHeaders(): void {
+    $r = new JsonResponse(
+      new ImmMap(['testing' => ImmMap{'HHVM' => 'Hack'}]),
+      StatusCode::ACCEPTED,
+      dict['X-App_Message' => vec['testing.'],
+      'content-type' => vec['application/hal+json']]
+    );
+    expect($r->getStatusCode())->toBeSame(202);
+    expect($r->getProtocolVersion())->toBeSame('1.1');
+    expect($r->getReasonPhrase())->toBeSame('Accepted');
+    expect($r->getHeaders())->toBeSame(dict[
+      'X-App_Message' => vec['testing.'],
+      'content-type' => vec['application/hal+json'],
+    ]);
+    expect($r->readBody()->rawReadBlocking())->toBeSame('{"testing":{"HHVM":"Hack"}}');
+  }
+}

--- a/tests/Response/RedirectResponseTest.php
+++ b/tests/Response/RedirectResponseTest.php
@@ -1,0 +1,44 @@
+<?hh // strict
+
+use type Ytake\Hungrr\Uri;
+use type Ytake\Hungrr\Response\RedirectResponse;
+use type Facebook\HackTest\HackTest;
+
+use namespace Ytake\Hungrr\Exception;
+use function Facebook\FBExpect\expect;
+
+final class RedirectResponseTest extends HackTest {
+
+  public function testShouldReturnRedirectHeaders(): void {
+    $r = new RedirectResponse('/foo/bar');
+    expect($r->getStatusCode())->toBeSame(302);
+    expect($r->hasHeader('Location'))->toBeTrue();
+    expect($r->getHeaderLine('Location'))->toBeSame('/foo/bar');
+  }
+
+  public function testShouldReturn302ResponseWithLocationHeader(): void {
+    $uri = new Uri('https://example.com:10082/foo/bar');
+    $r = new RedirectResponse($uri);
+    expect($r->getStatusCode())->toBeSame(302);
+    expect($r->hasHeader('Location'))->toBeTrue();
+    expect($r->getHeaderLine('Location'))->toBeSame((string) $uri);
+  }
+
+  public function dictUris(): dict<string, mixed> {
+    return dict[
+      'null'       => [ null ],
+      'false'      => [ false ],
+      'true'       => [ true ],
+      'zero'       => [ 0 ],
+      'int'        => [ 1 ],
+      'zero-float' => [ 0.0 ],
+      'float'      => [ 1.1 ],
+      'array'      => [ [ '/foo/bar' ] ],
+    ];
+  }
+
+  <<DataProvider('dictUris'), ExpectedException(Exception\InvalidArgumentException::class)>>
+  public function testConstructorRaisesExceptionOnInvalidUri(mixed $uri): void {
+    new RedirectResponse($uri);
+  }
+}

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -10,7 +10,7 @@ use function Facebook\FBExpect\expect;
 final class ResponseTest extends HackTest {
 
   public function testDefaultConstructor(): void {
-    $r = new Response();
+    $r = new Response('',);
     expect($r->getStatusCode())->toBeSame(200);
     expect($r->getProtocolVersion())->toBeSame('1.1');
     expect($r->getReasonPhrase())->toBeSame('OK');
@@ -19,13 +19,13 @@ final class ResponseTest extends HackTest {
   }
 
   public function testCanConstructWithStatusCode(): void {
-    $r = new Response(StatusCode::NOT_FOUND);
+    $r = new Response('', StatusCode::NOT_FOUND);
     expect($r->getStatusCode())->toBeSame(404);
     expect($r->getReasonPhrase())->toBeSame('Not Found');
   }
 
   public function testStatusCanBeNumericString(): void {
-    $r = new Response(StatusCode::NOT_FOUND);
+    $r = new Response('', StatusCode::NOT_FOUND);
     $r2 = $r->withStatus(StatusCode::CREATED);
     expect($r->getStatusCode())->toBeSame(404);
     expect($r->getReasonPhrase())->toBeSame('Not Found');
@@ -34,76 +34,76 @@ final class ResponseTest extends HackTest {
   }
 
   public function testCanConstructWithHeaders(): void {
-    $r = new Response(StatusCode::OK, dict['Foo' => vec['Bar']]);
+    $r = new Response('', StatusCode::OK, dict['Foo' => vec['Bar']]);
     expect($r->getHeaders())->toBeSame(dict['Foo' => vec['Bar']]);
     expect($r->getHeaderLine('Foo'))->toBeSame('Bar');
     expect($r->getHeader('Foo'))->toBeSame(vec['Bar']);
   }
 
   public function testCanConstructWithBody(): void {
-    $r = new Response(StatusCode::OK, dict[], 'baz');
+    $r = new Response('baz', StatusCode::OK, dict[]);
     expect($r->getBody())->toBeInstanceOf(IO\ReadHandle::class);
     expect($r->readBody()->rawReadBlocking())->toBeSame('baz');
   }
 
   public function testNullBody(): void {
-    $r = new Response(StatusCode::OK, dict[]);
+    $r = new Response('', StatusCode::OK, dict[]);
     expect($r->getBody())->toBeInstanceOf(IO\ReadHandle::class);
     expect($r->readBody()->rawReadBlocking())->toBeSame('');
   }
 
   public function testFalseyBody(): void {
-    $r = new Response(StatusCode::OK, dict[], '0');
+    $r = new Response('0', StatusCode::OK, dict[]);
     expect($r->getBody())->toBeInstanceOf(IO\ReadHandle::class);
     expect($r->readBody()->rawReadBlocking())->toBeSame('0');
   }
 
   public function testCanConstructWithReason(): void {
-    $r = new Response(StatusCode::OK, dict[], '', '1.1', 'bar');
+    $r = new Response('', StatusCode::OK, dict[], '1.1', 'bar');
     expect($r->getReasonPhrase())->toBeSame('bar');
-    $r = new Response(StatusCode::OK, dict[], '', '1.1', '0');
+    $r = new Response('', StatusCode::OK, dict[], '1.1', '0');
     expect($r->getReasonPhrase())->toBeSame('0');
   }
 
   public function testCanConstructWithProtocolVersion(): void {
-    $r = new Response(StatusCode::OK, dict[], '', '1000');
+    $r = new Response('', StatusCode::OK, dict[], '1000');
     expect($r->getProtocolVersion())->toBeSame('1000');
   }
 
   public function testWithStatusCodeAndNoReason(): void {
-    $r = (new Response())->withStatus(201);
+    $r = (new Response('',))->withStatus(201);
     expect($r->getStatusCode())->toBeSame(201);
     expect($r->getReasonPhrase())->toBeSame('Created');
   }
 
   public function testWithStatusCodeAndReason(): void {
-    $r = (new Response())->withStatus(201, 'Foo');
+    $r = (new Response('',))->withStatus(201, 'Foo');
     expect($r->getStatusCode())->toBeSame(201);
     expect($r->getReasonPhrase())->toBeSame('Foo');
-    $r = (new Response())->withStatus(201, '0');
+    $r = (new Response('',))->withStatus(201, '0');
     expect($r->getStatusCode())->toBeSame(201);
     expect($r->getReasonPhrase())->toBeSame('0');
   }
 
   public function testWithProtocolVersion(): void {
-    $r = (new Response())->withProtocolVersion('1000');
+    $r = (new Response('',))->withProtocolVersion('1000');
     expect($r->getProtocolVersion())->toBeSame('1000');
   }
 
   public function testSameInstanceWhenSameProtocol(): void {
-    $r = new Response();
+    $r = new Response('',);
     expect($r->withProtocolVersion('1.1'))->toBeSame($r);
   }
 
   public function testWithBody(): void {
-    $r = new Response();
+    $r = new Response('',);
     $r->setBody('testing');
     expect($r->getBody())->toBeInstanceOf(IO\ReadHandle::class);
     expect($r->readBody()->rawReadBlocking())->toBeSame('testing');
   }
 
   public function testWithHeader(): void {
-    $r = new Response(StatusCode::OK, dict['Foo' => vec['Bar']]);
+    $r = new Response('', StatusCode::OK, dict['Foo' => vec['Bar']]);
     $r2 = $r->withHeader('baZ', vec['Bam']);
     expect($r->getHeaders())->toBeSame(dict['Foo' => vec['Bar']]);
     expect($r2->getHeaders())->toBeSame(dict['Foo' => vec['Bar'], 'baZ' => vec['Bam']]);
@@ -112,7 +112,7 @@ final class ResponseTest extends HackTest {
   }
 
   public function testWithHeaderAsArray(): void {
-    $r = new Response(StatusCode::OK, dict['Foo' => vec['Bar']]);
+    $r = new Response('', StatusCode::OK, dict['Foo' => vec['Bar']]);
     $r2 = $r->withHeader('baZ', vec['Bam', 'Bar']);
     expect($r->getHeaders())->toBeSame(dict['Foo' => vec['Bar']]);
     expect($r2->getHeaders())->toBeSame(dict['Foo' => vec['Bar'], 'baZ' => vec['Bam', 'Bar']]);
@@ -121,7 +121,7 @@ final class ResponseTest extends HackTest {
   }
 
   public function testWithHeaderReplacesDifferentCase(): void {
-    $r = new Response(StatusCode::OK, dict['Foo' => vec['Bar']]);
+    $r = new Response('', StatusCode::OK, dict['Foo' => vec['Bar']]);
     $r2 = $r->withHeader('foO', vec['Bam']);
     expect($r->getHeaders())->toBeSame(dict['Foo' => vec['Bar']]);
     expect($r2->getHeaders())->toBeSame(dict['foO' => vec['Bam']]);
@@ -130,7 +130,7 @@ final class ResponseTest extends HackTest {
   }
 
   public function testWithAddedHeader(): void {
-    $r = new Response(StatusCode::OK, dict['Foo' => vec['Bar']]);
+    $r = new Response('', StatusCode::OK, dict['Foo' => vec['Bar']]);
     $r2 = $r->withAddedHeader('foO', vec['Baz']);
     expect($r->getHeaders())->toBeSame(dict['Foo' => vec['Bar']]);
     expect($r2->getHeaders())->toBeSame(dict['Foo' => vec['Bar', 'Baz']]);
@@ -139,7 +139,7 @@ final class ResponseTest extends HackTest {
   }
 
   public function testWithAddedHeaderAsArray(): void {
-    $r = new Response(StatusCode::OK, dict['Foo' => vec['Bar']]);
+    $r = new Response('', StatusCode::OK, dict['Foo' => vec['Bar']]);
     $r2 = $r->withAddedHeader('foO', vec['Baz', 'Bam']);
     expect($r->getHeaders())->toBeSame(dict['Foo' => vec['Bar']]);
     expect($r2->getHeaders())->toBeSame(dict['Foo' => vec['Bar', 'Baz', 'Bam']]);
@@ -148,7 +148,7 @@ final class ResponseTest extends HackTest {
   }
 
   public function testWithAddedHeaderThatDoesNotExist(): void {
-    $r = new Response(StatusCode::OK, dict['Foo' => vec['Bar']]);
+    $r = new Response('', StatusCode::OK, dict['Foo' => vec['Bar']]);
     $r2 = $r->withAddedHeader('nEw', vec['Baz']);
     expect($r->getHeaders())->toBeSame(dict['Foo' => vec['Bar']]);
     expect($r2->getHeaders())->toBeSame(dict['Foo' => vec['Bar'], 'nEw' => vec['Baz']]);
@@ -157,7 +157,7 @@ final class ResponseTest extends HackTest {
   }
 
   public function testWithoutHeaderThatExists(): void {
-    $r = new Response(StatusCode::OK, dict['Foo' => vec['Bar'], 'Baz' => vec['Bam']]);
+    $r = new Response('', StatusCode::OK, dict['Foo' => vec['Bar'], 'Baz' => vec['Bam']]);
     $r2 = $r->withoutHeader('foO');
     expect($r->hasHeader('foo'))->toBeTrue();
     expect($r->getHeaders())->toBeSame(dict['Foo' => vec['Bar'], 'Baz' => vec['Bam']]);
@@ -166,7 +166,7 @@ final class ResponseTest extends HackTest {
   }
 
   public function testWithoutHeaderThatDoesNotExist(): void {
-    $r = new Response(StatusCode::OK, dict['Baz' => vec['Bam']]);
+    $r = new Response('', StatusCode::OK, dict['Baz' => vec['Bam']]);
     $r2 = $r->withoutHeader('foO');
     expect($r2)->toBeSame($r);
     expect($r2->hasHeader('foo'))->toBeFalse();
@@ -174,15 +174,15 @@ final class ResponseTest extends HackTest {
   }
 
   public function testSameInstanceWhenRemovingMissingHeader(): void {
-    $r = new Response();
+    $r = new Response('',);
     expect($r->withoutHeader('foo'))->toBeSame($r);
   }
 
   public function trimmedHeaderValues(): vec<(Response)> {
     return vec[
-      tuple(new Response(StatusCode::OK, dict['OWS' => vec[" \t \tFoo\t \t "]])),
-      tuple((new Response())->withHeader('OWS', vec[" \t \tFoo\t \t "])),
-      tuple((new Response())->withAddedHeader('OWS', vec[" \t \tFoo\t \t "])),
+      tuple(new Response('',StatusCode::OK, dict['OWS' => vec[" \t \tFoo\t \t "]])),
+      tuple((new Response('',))->withHeader('OWS', vec[" \t \tFoo\t \t "])),
+      tuple((new Response('',))->withAddedHeader('OWS', vec[" \t \tFoo\t \t "])),
     ];
   }
 


### PR DESCRIPTION
# Feature

## Json Response

Constructor Detail

```text
public function __construct(
  ImmMap<mixed, mixed> $payload,
  Ytake\Hungrr\StatusCode $status,
  dict<string, vec<string>> $headers,
  int $encodingOptions
)
```

Example

```hack
<?hh // strict

use type Ytake\Hungrr\Uri;
use type Ytake\Hungrr\StatusCode;
use type Ytake\Hungrr\Response\RedirectResponse;

$r = new JsonResponse(new ImmMap([
  'json_encode' => ImmMap{
    'HHVM' => 'Hack'
  }
]));
```

## Redirect Response

Constructor Detail

```text
public function __construct(
  mixed $uri,
  Ytake\Hungrr\StatusCode $status,
  dict<string, vec<string>> $headers
)
```

$uri, MUST be a string or Facebook\Experimental\Http\Message\UriInterface instance.

Example

```hack
<?hh // strict

use type Ytake\Hungrr\Uri;
use type Ytake\Hungrr\StatusCode;
use type Ytake\Hungrr\Response\RedirectResponse;

// use uri string
$r = new RedirectResponse('/foo/bar');

// use uri instance
$r = new RedirectResponse(new Uri('https://example.com:10082/foo/bar'));
```

and more.